### PR TITLE
Fixed make doc when not running INTEL. Added different captioning and position depending on your flags.

### DIFF
--- a/document/fpga.tex
+++ b/document/fpga.tex
@@ -23,7 +23,7 @@
 \hline
 \input alt_results.tex 
 \end{tabular}
-\fi
 \end{minipage}
+\fi
 \caption{Kintex Ultrascale (left) and Cyclone V GT (right)}
 \end{table}

--- a/document/fpga.tex
+++ b/document/fpga.tex
@@ -1,6 +1,10 @@
 \begin{table}[H]
 \ifnum\XILINX=1
-\begin{minipage}{.45\linewidth}
+\ifnum\INTEL=1
+\begin{minipage}{0.45\linewidth}
+\else
+\begin{minipage}{\linewidth}
+\fi
 \centering
 \begin{tabular}{|l|r|}
 \hline
@@ -13,7 +17,11 @@
 \end{minipage}
 \fi
 \ifnum\INTEL=1
-\begin{minipage}{.45\linewidth}
+\ifnum\XILINX=1
+\begin{minipage}{0.45\linewidth}
+\else
+\begin{minipage}{\linewidth}
+\fi
 \centering
 \begin{tabular}{|l|r|}
 \hline
@@ -39,4 +47,3 @@
 \fi
 \fi
 \end{table}
-

--- a/document/fpga.tex
+++ b/document/fpga.tex
@@ -25,5 +25,18 @@
 \end{tabular}
 \end{minipage}
 \fi
+\ifnum\INTEL=1
+\ifnum\XILINX=1
 \caption{Kintex Ultrascale (left) and Cyclone V GT (right)}
+\fi
+\ifnum\XILINX=0
+\caption{Cyclone V GT}
+\fi
+\fi
+\ifnum\XILINX=1
+\ifnum\INTEL=0
+\caption{Kintex Ultrascale}
+\fi
+\fi
 \end{table}
+


### PR DESCRIPTION
If running intel = 0 fpga.tex was trying to end minipage when it didn't even began.
Centered table when only running one of the boards.
Also changed table captioning to adapt theses cases.
