### PR TITLE
fpga2tex only chooses first matching pattern from vivado.log

### DIFF
--- a/software/fpga2tex.sh
+++ b/software/fpga2tex.sh
@@ -28,11 +28,11 @@ fi
 if [ $XILINX = 1 ]; then \
 LOG="vivado.log" ;\
 RES="xil_results.tex" ;\
-LUT=`grep -o 'LUTs\ *|\ * [0-9]*' vivado.log | sed s/'| L'/L/g | sed s/\|/'\&'/g` ;\
-FF=`grep -o 'Registers\ *|\ * [0-9]*' vivado.log | sed s/'| L'/L/g | sed s/\|/'\&'/g` ;\
-DSP=`grep -o 'DSPs\ *|\ * [0-9]*' vivado.log | sed s/'| L'/L/g | sed s/\|/'\&'/g` ;\
-BRAM=`grep -o 'Block RAM Tile \ *|\ * [0-9]*' vivado.log | sed s/'| L'/L/g | sed s/\|/'\&'/g | sed s/lock\ //g | sed s/Tile//g` ;\
-PIN=`grep -o 'Bonded IOB\ *|\ * [0-9]*' vivado.log | sed s/'| L'/L/g | sed s/\|/'\&'/g | sed s/'Bonded IOB'/PIN/g` ;\
+LUT=`grep -m1 -o 'LUTs\ *|\ * [0-9]*' vivado.log | sed s/'| L'/L/g | sed s/\|/'\&'/g` ;\
+FF=`grep -m1 -o 'Registers\ *|\ * [0-9]*' vivado.log | sed s/'| L'/L/g | sed s/\|/'\&'/g` ;\
+DSP=`grep -m1 -o 'DSPs\ *|\ * [0-9]*' vivado.log | sed s/'| L'/L/g | sed s/\|/'\&'/g` ;\
+BRAM=`grep -m1 -o 'Block RAM Tile \ *|\ * [0-9]*' vivado.log | sed s/'| L'/L/g | sed s/\|/'\&'/g | sed s/lock\ //g | sed s/Tile//g` ;\
+PIN=`grep -m1 -o 'Bonded IOB\ *|\ * [0-9]*' vivado.log | sed s/'| L'/L/g | sed s/\|/'\&'/g | sed s/'Bonded IOB'/PIN/g` ;\
 echo "$LUT \\\\ \\hline"  > $RES ;\
 echo "\rowcolor{iob-blue}"  >> $RES ;\
 echo "$FF  \\\\  \\hline" >> $RES ;\


### PR DESCRIPTION
Depending on fpga synthesis options, .log files can generate multiple tables matching the `grep` pattern.
This, in turn, generates lines with too many columns, which trigger a latex compilation error for documentation.
Changes only done for xilinx .log files.