### PR TITLE
Uniform path variable for interface tables

### DIFF
--- a/document/document.mk
+++ b/document/document.mk
@@ -51,7 +51,7 @@ cpu_nat_s_is_tab.tex: $(INTERCON_DIR)/hardware/include/cpu_nat_s_if.v
 	$(TEX_SW_DIR)/io2tex.py $< $@
 
 cpu_axi4_m_is_tab.tex: $(INTERCON_DIR)/hardware/include/cpu_axi4_m_if.v
-	$(SW_DIR)/io2tex.py $< $@
+	$(TEX_SW_DIR)/io2tex.py $< $@
 
 cpu_axi4lite_s_is_tab.tex: $(INTERCON_DIR)/hardware/include/cpu_axi4lite_s_if.v
 	$(TEX_SW_DIR)/io2tex.py $< $@


### PR DESCRIPTION
- cpu_axi4_m_is_tab.tex had a different enviroment variable for path than other targets