### PR TITLE
fix(sw): Fix minor bug in vhparser

### DIFF
--- a/software/io2tex.py
+++ b/software/io2tex.py
@@ -27,10 +27,13 @@ def io_parse (program, defines) :
         flds_out[1] = re.sub('`','', flds[0]).lower() #signal direction
 
         flds_out[0] = re.sub('_','\_',flds[1]) #signal name
-        for key, val in defines.items():
-            if key in str(flds[2]):
-                flds[2] = eval(re.sub(str(key),str(val), flds[2]))
-            pass
+        if flds[2] in defines:#check for matching key first
+            flds[2] = defines[flds[2]]
+        else: #macro composed by multiple defines
+            for key, val in defines.items():
+                if key in str(flds[2]):
+                    flds[2] = eval(re.sub(str(key),str(val), flds[2]))
+                pass
         flds_out[2] = re.sub('_', '\_', str(flds[2]))  #signal width
         flds_out[3] = re.sub('_','\_'," ".join(flds[3:])) #signal description
 


### PR DESCRIPTION
- Prioritize replacing define field by matching key
- This avoids a bug of wrong replacement. 
- The bug case had:
```
# defines.vh
`define RHO 98765246
`define RHO_W 35
# source io to be replaced
`INPUT(rho, `RHO_W)
```
Here we have `RHO_W` macro to be replaced, but since `RHO` was also a define and was first in the
dictionary order, the script was replacing `RHO_W` with ``(`RHO value)_W`` = `984621351_W`, which caused python to exit with an error.